### PR TITLE
The verify account button is replaced

### DIFF
--- a/client/src/components/Screens/HomePage/index.jsx
+++ b/client/src/components/Screens/HomePage/index.jsx
@@ -1,8 +1,7 @@
 import styles from "./styles.module.css";
 import { googleLogout } from "@react-oauth/google";
-import { sendVerifyEmail } from "../../axios";
+
 import React from "react";
-import { useState } from "react";
 
 const HomePage = () => {
   const handleLogout = () => {
@@ -12,36 +11,11 @@ const HomePage = () => {
     window.location.reload();
   };
 
- 
-  const [error, setError] = useState("");
-  const [msg, setMsg] = useState("");
-  const user = JSON.parse(localStorage.getItem("user"));
-
-  const [data] = useState({
-    email: user.email,
-  });
   return (
     <div>
       <button className={styles.logout_button} onClick={handleLogout}>
         Logout
       </button>
-
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          sendVerifyEmail(data)
-            .then(() => {
-              setMsg("An email sent to your account please verify !");
-            })
-            .catch((err) => {
-              setError(err.response.data.message);
-              setMsg("");
-            });
-        }}
-      >
-        <button className={styles.logout_button}>Verify My Account</button>
-      </form>
-      <h1>{msg}</h1>
     </div>
   );
 };

--- a/client/src/components/Screens/UserPage/UserPage.jsx
+++ b/client/src/components/Screens/UserPage/UserPage.jsx
@@ -1,12 +1,19 @@
 import { useNavigate } from "react-router-dom";
+import { useState } from "react";
 import { FcCheckmark, FcCancel } from "react-icons/fc";
+import { sendVerifyEmail } from "../../axios";
 
 import styles from "./styles.module.css";
+
 const UserPage = () => {
-  console.log("USERPAGE");
   const user = JSON.parse(localStorage.getItem("user"));
 
   const navigate = useNavigate();
+  const [error, setError] = useState("");
+  const [msg, setMsg] = useState("");
+  const data = {
+    email: user.email,
+  };
 
   const handleUpdate = () => {
     navigate("/profile/update");
@@ -26,6 +33,18 @@ const UserPage = () => {
         ></img>
         <h4>{user.fullname}</h4>
         <p>{user.nickname}</p>
+
+        <div className={styles.button_div}>
+          <form onSubmit={handleUpdate}>
+            <button stype="button" onClick={handleUpdate}>
+              Update
+            </button>
+
+            <button stype="button" onClick={handleDelete}>
+              Delete
+            </button>
+          </form>
+        </div>
       </div>
 
       <div className={styles.right}>
@@ -42,6 +61,29 @@ const UserPage = () => {
                   {user.verified ? <FcCheckmark /> : <FcCancel />}
                 </b>
               </p>
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  sendVerifyEmail(data)
+                    .then(() => {
+                      setMsg(
+                        "An email sent to your email address please verify!"
+                      );
+                    })
+                    .catch((err) => {
+                      setError(err.response.data.message);
+                      setMsg("");
+                    });
+                }}
+              >
+                <button
+                  disabled={user.verified}
+                  className={styles.verify_email_button}
+                >
+                  {user.verified ? "Account is verified" : "Verify My Account"}
+                </button>
+              </form>
+              <p className={styles.sent_message}>{msg}</p>
             </div>
 
             <div className={styles.data}>
@@ -63,26 +105,6 @@ const UserPage = () => {
               <p>PLACEHOLDER</p>
             </div>
           </div>
-        </div>
-
-        <div className={styles.button_div}>
-          <form onSubmit={handleUpdate}>
-            <button
-              stype="button"
-              className={styles.purple_btn}
-              onClick={handleUpdate}
-            >
-              Update
-            </button>
-
-            <button
-              stype="button"
-              className={styles.purple_btn}
-              onClick={handleDelete}
-            >
-              Delete
-            </button>
-          </form>
         </div>
       </div>
     </div>

--- a/client/src/components/Screens/UserPage/styles.module.css
+++ b/client/src/components/Screens/UserPage/styles.module.css
@@ -146,11 +146,13 @@
 
 .wrapper .button_div form {
   display: flex;
-  justify-content: right;
+  margin-top: 210px;
+  justify-content: left;
 }
 
 .wrapper .button_div button {
   background: linear-gradient(to right, #01a9ac, #01dbdf);
+  align-self: flex-end;
   margin-right: 10px;
   border-radius: 5px;
   text-align: center;
@@ -165,6 +167,55 @@
   color: #fff;
   display: block;
   font-size: 16px;
+}
+
+.verify_email_button {
+  background-color: #13aa52;
+  border: 1px solid #13aa52;
+  border-radius: 4px;
+  box-shadow: rgba(0, 0, 0, 0.1) 0 2px 4px 0;
+
+  color: #fff;
+  cursor: pointer;
+  font-family: "Akzidenz Grotesk BQ Medium", -apple-system, BlinkMacSystemFont,
+    sans-serif;
+
+  outline: none;
+  outline: 0;
+  font-size: 12px;
+  text-align: center;
+
+  transform: translateY(0);
+  transition: transform 150ms, box-shadow 150ms;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+  width: 120px;
+  height: 22px;
+}
+
+.verify_email_button:hover {
+  box-shadow: rgba(0, 0, 0, 0.15) 0 3px 9px 0;
+  transform: translateY(-1px);
+}
+
+.wrapper .right .info_data .data .sent_message {
+  color: #13aa52;
+  font-style: italic;
+}
+
+.verify_email_button:disabled,
+.verify_email_button[disabled] {
+  border: 1px solid #999999;
+  background-color: #cccccc;
+  color: #666666;
+  cursor: no-drop;
+}
+
+.verify_email_button:disabled:hover,
+.verify_email_button[disabled]:hover {
+  box-shadow: none;
+  transform: none;
 }
 
 /* PROFILE CARD CSS END */


### PR DESCRIPTION
The verify email button which is currently on the index.jsx of main page, and sends tokens for confirmation of mails, was replaced in my profile section and placed there next to the text that is showing the verification status of the account.